### PR TITLE
Convert contracts to macros for more seamless operation

### DIFF
--- a/contract/social.rkt
+++ b/contract/social.rkt
@@ -10,8 +10,8 @@
 
 (provide
  function/c
+ thunk/c
  (contract-out [self-map/c (self-map/c contract?)]
-               [thunk/c (->* () (contract?) contract?)]
                [binary-function/c (->* ()
                                        (contract?
                                         (maybe/c contract?)
@@ -79,8 +79,9 @@
 (define (self-map/c type/c)
   (function/c type/c type/c))
 
-(define (thunk/c [target/c any/c])
-  (-> target/c))
+(define-syntax-parser thunk/c
+  [(_ (~optional target/c #:defaults ([target/c #'any/c])))
+   #'(-> target/c)])
 
 (define (binary-function/c [a/c any/c]
                            [b/c #f]

--- a/contract/social.rkt
+++ b/contract/social.rkt
@@ -27,13 +27,10 @@
  encoder/c
  decoder/c
  hash-function/c
- (contract-out [maybe/c (->* (contract?)
-                             (contract?)
-                             contract?)]
-               [binary-composition/c (self-map/c contract?)]
-               [variadic-composition/c (self-map/c contract?)]
-               [binary-variadic-composition/c (self-map/c contract?)]
-               [classifier/c (->* ()
+ maybe/c
+ binary-composition/c
+ variadic-composition/c
+ (contract-out [classifier/c (->* ()
                                   (contract?)
                                   contract?)]
                [map/c (->* ()
@@ -88,10 +85,12 @@
   [(_ source/c target/c)
    #:with ··· (quote-syntax ...)
    #'(-> source/c ··· target/c)]
-  [(_) #:with ··· (quote-syntax ...) ; backwards compat - remove later
-       #'(-> any/c ··· any/c)]
-  [_ #:with ··· (quote-syntax ...)
-     #'(-> any/c ··· any/c)])
+  [(_)
+   #:with ··· (quote-syntax ...) ; backwards compat - remove later
+   #'(-> any/c ··· any/c)]
+  [_
+   #:with ··· (quote-syntax ...)
+   #'(-> any/c ··· any/c)])
 
 ;; review variadic as the need presents itself
 
@@ -125,17 +124,16 @@
   [(_) #'(encoder/c fixnum?)] ; backwards compat - remove later
   [_ #'(encoder/c fixnum?)])
 
-(define (maybe/c type/c [default/c #f])
-  (or/c type/c default/c))
+(define-syntax-parser maybe/c
+  [(_ type/c (~optional default/c #:defaults ([default/c #'#f])))
+   #'(or/c type/c default/c)])
 
-(define (binary-composition/c type/c)
+(define-syntax-parse-rule (binary-composition/c type/c)
   (binary-function/c type/c type/c type/c))
 
-(define (variadic-composition/c type/c)
-  (variadic-function/c type/c type/c))
-
-(define (binary-variadic-composition/c type/c)
-  (variadic-function/c type/c))
+(define-syntax-parser variadic-composition/c
+  [(_ type/c) #'(variadic-function/c type/c type/c)]
+  [(_ type/c _) #'(variadic-function/c type/c type/c type/c)]) ; support minimum required arity instead?
 
 (define (classifier/c [by-type/c any/c])
   (binary-function/c (encoder/c by-type/c)

--- a/contract/social.rkt
+++ b/contract/social.rkt
@@ -81,8 +81,9 @@
                                             contract?)]))
 
 (define-syntax-parser function/c
-  [(_) #'(-> any/c any/c)]
-  [(_ source/c target/c) #'(-> source/c target/c)])
+  [(_ source/c target/c) #'(-> source/c target/c)]
+  [(_) #'(-> any/c any/c)] ; backwards compat - remove later
+  [_ #'(-> any/c any/c)])
 
 (define-syntax-parse-rule (self-map/c type/c)
   (function/c type/c type/c))

--- a/contract/social.rkt
+++ b/contract/social.rkt
@@ -69,6 +69,9 @@
   [(_ source/c target/c)
    #:with ··· (quote-syntax ...)
    #'(-> source/c ··· target/c)]
+  [(_ source/c)
+   #:with ··· (quote-syntax ...)
+   #'(-> source/c ··· any/c)]
   [(_)
    #:with ··· (quote-syntax ...) ; backwards compat - remove later
    #'(-> any/c ··· any/c)]

--- a/contract/social.rkt
+++ b/contract/social.rkt
@@ -21,10 +21,8 @@
  thunk/c
  self-map/c
  binary-function/c
- (contract-out [variadic-function/c (->* ()
-                                         (contract? (maybe/c contract?))
-                                         contract?)]
-               [binary-variadic-function/c (->* ()
+ variadic-function/c
+ (contract-out [binary-variadic-function/c (->* ()
                                                 (contract?
                                                  (maybe/c contract?)
                                                  (maybe/c contract?)
@@ -93,10 +91,14 @@
   [(_) #'(-> any/c any/c any/c)] ; backwards compat - remove later
   [_ #'(-> any/c any/c any/c)])
 
-(define (variadic-function/c [source/c any/c]
-                             [target/c #f])
-  (let ([target/c (or target/c source/c)])
-    (-> source/c ... target/c)))
+(define-syntax-parser variadic-function/c
+  [(_ source/c target/c)
+   #:with ··· (quote-syntax ...)
+   #'(-> source/c ··· target/c)]
+  [(_) #:with ··· (quote-syntax ...) ; backwards compat - remove later
+       #'(-> any/c ··· any/c)]
+  [_ #:with ··· (quote-syntax ...)
+     #'(-> any/c ··· any/c)])
 
 (define (binary-variadic-function/c [a/c any/c]
                                     [b/c #f]

--- a/contract/social.rkt
+++ b/contract/social.rkt
@@ -20,12 +20,8 @@
  function/c
  thunk/c
  self-map/c
- (contract-out [binary-function/c (->* ()
-                                       (contract?
-                                        (maybe/c contract?)
-                                        (maybe/c contract?))
-                                       contract?)]
-               [variadic-function/c (->* ()
+ binary-function/c
+ (contract-out [variadic-function/c (->* ()
                                          (contract? (maybe/c contract?))
                                          contract?)]
                [binary-variadic-function/c (->* ()
@@ -92,12 +88,10 @@
   [(_ (~optional target/c #:defaults ([target/c #'any/c])))
    #'(-> target/c)])
 
-(define (binary-function/c [a/c any/c]
-                           [b/c #f]
-                           [target/c #f])
-  (let ([b/c (or b/c a/c)]
-        [target/c (or target/c a/c)])
-    (-> a/c b/c target/c)))
+(define-syntax-parser binary-function/c
+  [(_ a/c b/c target/c) #'(-> a/c b/c target/c)]
+  [(_) #'(-> any/c any/c any/c)] ; backwards compat - remove later
+  [_ #'(-> any/c any/c any/c)])
 
 (define (variadic-function/c [source/c any/c]
                              [target/c #f])

--- a/contract/social.rkt
+++ b/contract/social.rkt
@@ -24,9 +24,9 @@
  predicate/c
  binary-predicate/c
  variadic-predicate/c
- (contract-out [encoder/c (self-map/c contract?)]
-               [decoder/c (self-map/c contract?)]
-               [hash-function/c (thunk/c contract?)]
+ encoder/c
+ decoder/c
+ (contract-out [hash-function/c (thunk/c contract?)]
                [maybe/c (->* (contract?)
                              (contract?)
                              contract?)]
@@ -115,10 +115,10 @@
   [(_) #'(variadic-function/c any/c boolean?)] ; backwards compat - remove later
   [_ #'(variadic-function/c any/c boolean?)])
 
-(define (encoder/c as-type/c)
+(define-syntax-parse-rule (encoder/c as-type/c)
   (function/c any/c as-type/c))
 
-(define (decoder/c from-type/c)
+(define-syntax-parse-rule (decoder/c from-type/c)
   (function/c from-type/c any/c))
 
 (define (hash-function/c)

--- a/contract/social.rkt
+++ b/contract/social.rkt
@@ -42,7 +42,7 @@
 (define-syntax-parser function/c
   [(_ source/c target/c) #'(-> source/c target/c)]
   [(_) #'(-> any/c any/c)] ; backwards compat - remove later
-  [_ #'(-> any/c any/c)])
+  [_:id #'(-> any/c any/c)])
 
 (define-syntax-parse-rule (self-map/c type/c)
   (function/c type/c type/c))
@@ -50,14 +50,14 @@
 (define-syntax-parser thunk/c
   [(_ target/c) #'(-> target/c)]
   [(_) #'(-> any/c)] ; backwards compat - remove later
-  [_ #'(-> any/c)])
+  [_:id #'(-> any/c)])
 
 (define-syntax-parser binary-function/c
   [(_ a/c b/c target/c) #'(-> a/c b/c target/c)]
   [(_ type/c) #'(-> type/c type/c any/c)]
   [(_ type/c target/c) #'(-> type/c type/c target/c)]
   [(_) #'(-> any/c any/c any/c)] ; backwards compat - remove later
-  [_ #'(-> any/c any/c any/c)])
+  [_:id #'(-> any/c any/c any/c)])
 
 (define-syntax-parser variadic-function/c
   [(_ a/c ((~datum tail) b/c) target/c)
@@ -72,7 +72,7 @@
   [(_)
    #:with ··· (quote-syntax ...) ; backwards compat - remove later
    #'(-> any/c ··· any/c)]
-  [_
+  [_:id
    #:with ··· (quote-syntax ...)
    #'(-> any/c ··· any/c)])
 
@@ -82,14 +82,14 @@
 
 (define-syntax-parser predicate/c
   [(_ on-type/c) #'(function/c on-type/c boolean?)]
-  [(_) #'(predicate/c any/c)]
-  [_ #'(predicate/c any/c)])
+  [(_) #'(predicate/c any/c)] ; backwards compat - remove later
+  [_:id #'(predicate/c any/c)])
 
 (define-syntax-parser binary-predicate/c
   [(_ a/c b/c) #'(binary-function/c a/c b/c boolean?)]
   [(_ on-type/c) #'(binary-predicate/c on-type/c on-type/c)]
   [(_) #'(binary-predicate/c any/c)] ; backwards compat - remove later
-  [_ #'(binary-predicate/c any/c)])
+  [_:id #'(binary-predicate/c any/c)])
 
 (define-syntax-parser variadic-predicate/c
   [(_ a/c ((~datum tail) b/c))
@@ -98,7 +98,7 @@
    #'(variadic-function/c a/c b/c boolean?)]
   [(_ source/c) #'(variadic-function/c source/c boolean?)]
   [(_) #'(variadic-predicate/c any/c)] ; backwards compat - remove later
-  [_ #'(variadic-predicate/c any/c)])
+  [_:id #'(variadic-predicate/c any/c)])
 
 (define-syntax-parse-rule (encoder/c as-type/c)
   (function/c any/c as-type/c))
@@ -108,7 +108,7 @@
 
 (define-syntax-parser hash-function/c
   [(_) #'(encoder/c fixnum?)] ; backwards compat - remove later
-  [_ #'(encoder/c fixnum?)])
+  [_:id #'(encoder/c fixnum?)])
 
 (define-syntax-parser maybe/c
   [(_ type/c default/c) #'(or/c type/c default/c)]
@@ -130,7 +130,7 @@
                                       sequence?
                                       (sequenceof sequence?))]
   [(_) #'(classifier/c any/c)] ; backward compat - remove later
-  [_ #'(classifier/c any/c)])
+  [_:id #'(classifier/c any/c)])
 
 (define-syntax-parser map/c
   [(_ source/c target/c) #'(binary-function/c (function/c source/c target/c)
@@ -138,26 +138,26 @@
                                               (sequenceof target/c))]
   [(_ source/c) #'(map/c source/c source/c)]
   [(_) #'(map/c any/c any/c)] ; backward compat - remove later
-  [_ #'(map/c any/c any/c)])
+  [_:id #'(map/c any/c any/c)])
 
 (define-syntax-parser filter/c
   [(_ of-type/c) #'(binary-function/c (predicate/c of-type/c)
                                       (sequenceof of-type/c)
                                       (sequenceof of-type/c))]
   [(_) #'(filter/c any/c)] ; backward compat - remove later
-  [_ #'(filter/c any/c)])
+  [_:id #'(filter/c any/c)])
 
 (define-syntax-parser reducer/c
   [(_ type/c target/c) #'(function/c (sequenceof type/c)
                                      target/c)]
   [(_ type/c) #'(reducer/c type/c type/c)]
   [(_) #'(reducer/c any/c)] ; backward compat - remove later
-  [_ #'(reducer/c any/c)])
+  [_:id #'(reducer/c any/c)])
 
 (define-syntax-parser functional/c
   [(_ procedure/c) #'(self-map/c procedure/c)]
   [(_) #'(functional/c procedure?)] ; backward compat - remove later
-  [_ #'(functional/c procedure?)])
+  [_:id #'(functional/c procedure?)])
 
 (define-syntax-parser binary-constructor/c
   [(_ (~seq #:order (~datum 'abb)) primitive/c composite/c)

--- a/contract/social.rkt
+++ b/contract/social.rkt
@@ -57,12 +57,6 @@
   [(_) #'(-> any/c any/c any/c)] ; backwards compat - remove later
   [_ #'(-> any/c any/c any/c)])
 
-;; TODO: support any number of contracts preceding
-;; the variadic argument.
-;; maybe DSL-ify it so that we can indicate the arity
-;; of distinct contracts beforehand, so that they can
-;; default to the right _number_ of them, and can be
-;; left unspecified
 (define-syntax-parser variadic-function/c
   [(_ a/c ((~datum tail) b/c) target/c)
    #:with ··· (quote-syntax ...)

--- a/contract/social.rkt
+++ b/contract/social.rkt
@@ -3,16 +3,24 @@
 (require racket/contract
          racket/match
          syntax/parse/define
+         version-case
+         (only-in mischief/shorthand define-alias)
          (for-syntax racket/base)
          (only-in data/collection
                   sequenceof
                   sequence?))
 
+(version-case
+ [(version< (version) "7.9.0.22")
+  (define-alias define-syntax-parse-rule define-simple-macro)]
+ [else
+  (define-alias define-syntax-parse-rule define-syntax-parse-rule)])
+
 (provide
  function/c
  thunk/c
- (contract-out [self-map/c (self-map/c contract?)]
-               [binary-function/c (->* ()
+ self-map/c
+ (contract-out [binary-function/c (->* ()
                                        (contract?
                                         (maybe/c contract?)
                                         (maybe/c contract?))
@@ -76,7 +84,7 @@
   [(_) #'(-> any/c any/c)]
   [(_ source/c target/c) #'(-> source/c target/c)])
 
-(define (self-map/c type/c)
+(define-syntax-parse-rule (self-map/c type/c)
   (function/c type/c type/c))
 
 (define-syntax-parser thunk/c

--- a/contract/social.rkt
+++ b/contract/social.rkt
@@ -36,9 +36,7 @@
  reducer/c
  functional/c
  binary-constructor/c
- (contract-out [variadic-constructor/c (->* (contract? contract?)
-                                            (#:order (one-of/c 'abb 'bab))
-                                            contract?)]))
+ variadic-constructor/c)
 
 (define-syntax-parser function/c
   [(_ source/c target/c) #'(-> source/c target/c)]
@@ -179,11 +177,13 @@
    #'(binary-function/c composite/c primitive/c composite/c)]
   [(_ primitive/c composite/c)
    ;; default to abb order
-   #'(binary-function/c primitive/c composite/c composite/c)])
+   #'(binary-constructor/c #:order 'abb primitive/c composite/c)])
 
-(define (variadic-constructor/c primitive/c
-                                composite/c
-                                #:order [order 'abb])
-  (match order
-    ['abb (variadic-function/c #:tail? #t primitive/c composite/c composite/c)]
-    ['bab (variadic-function/c composite/c primitive/c composite/c)]))
+(define-syntax-parser variadic-constructor/c
+  [(_ (~seq #:order (~datum 'abb)) primitive/c composite/c)
+   #'(variadic-function/c primitive/c (tail composite/c) composite/c)]
+  [(_ (~seq #:order (~datum 'bab)) primitive/c composite/c)
+   #'(variadic-function/c composite/c primitive/c composite/c)]
+  [(_ primitive/c composite/c)
+   ;; default to abb order
+   #'(variadic-constructor/c #:order 'abb primitive/c composite/c)])

--- a/contract/social.rkt
+++ b/contract/social.rkt
@@ -2,15 +2,15 @@
 
 (require racket/contract
          racket/match
+         syntax/parse/define
+         (for-syntax racket/base)
          (only-in data/collection
                   sequenceof
                   sequence?))
 
 (provide
- (contract-out [function/c (case->
-                            (-> contract?)
-                            (-> contract? contract? contract?))]
-               [self-map/c (self-map/c contract?)]
+ function/c
+ (contract-out [self-map/c (self-map/c contract?)]
                [thunk/c (->* () (contract?) contract?)]
                [binary-function/c (->* ()
                                        (contract?
@@ -72,11 +72,9 @@
                                             (#:order (one-of/c 'abb 'bab))
                                             contract?)]))
 
-(define function/c
-  (case-lambda
-    [() (-> any/c any/c)]
-    [(source/c target/c)
-     (-> source/c target/c)]))
+(define-syntax-parser function/c
+  [(_) #'(-> any/c any/c)]
+  [(_ source/c target/c) #'(-> source/c target/c)])
 
 (define (self-map/c type/c)
   (function/c type/c type/c))

--- a/contract/social.rkt
+++ b/contract/social.rkt
@@ -83,14 +83,14 @@
 
 (define-syntax-parser predicate/c
   [(_ on-type/c) #'(function/c on-type/c boolean?)]
-  [(_) #'(function/c any/c boolean?)]
-  [_ #'(function/c any/c boolean?)])
+  [(_) #'(predicate/c any/c)]
+  [_ #'(predicate/c any/c)])
 
 (define-syntax-parser binary-predicate/c
   [(_ a/c b/c) #'(binary-function/c a/c b/c boolean?)]
-  [(_ on-type/c) #'(binary-function/c on-type/c on-type/c boolean?)]
-  [(_) #'(binary-function/c any/c any/c boolean?)] ; backwards compat - remove later
-  [_ #'(binary-function/c any/c any/c boolean?)])
+  [(_ on-type/c) #'(binary-predicate/c on-type/c on-type/c)]
+  [(_) #'(binary-predicate/c any/c)] ; backwards compat - remove later
+  [_ #'(binary-predicate/c any/c)])
 
 (define-syntax-parser variadic-predicate/c
   [(_ a/c ((~datum tail) b/c))
@@ -98,8 +98,8 @@
   [(_ a/c b/c)
    #'(variadic-function/c a/c b/c boolean?)]
   [(_ source/c) #'(variadic-function/c source/c boolean?)]
-  [(_) #'(variadic-function/c any/c boolean?)] ; backwards compat - remove later
-  [_ #'(variadic-function/c any/c boolean?)])
+  [(_) #'(variadic-predicate/c any/c)] ; backwards compat - remove later
+  [_ #'(variadic-predicate/c any/c)])
 
 (define-syntax-parse-rule (encoder/c as-type/c)
   (function/c any/c as-type/c))
@@ -126,49 +126,35 @@
   [(_ by-type/c) #'(binary-function/c (encoder/c by-type/c)
                                       sequence?
                                       (sequenceof sequence?))]
-  [(_) #'(binary-function/c (encoder/c any/c)
-                            sequence?
-                            (sequenceof sequence?))] ; backward compat - remove later
-  [_ #'(binary-function/c (encoder/c any/c)
-                          sequence?
-                          (sequenceof sequence?))])
+  [(_) #'(classifier/c any/c)] ; backward compat - remove later
+  [_ #'(classifier/c any/c)])
 
 (define-syntax-parser map/c
   [(_ source/c target/c) #'(binary-function/c (function/c source/c target/c)
                                               (sequenceof source/c)
                                               (sequenceof target/c))]
-  [(_ source/c) #'(binary-function/c (self-map/c source/c)
-                                     (sequenceof source/c)
-                                     (sequenceof source/c))]
-  [(_) #'(binary-function/c function/c
-                            sequence?
-                            sequence?)] ; backward compat - remove later
-  [_ #'(binary-function/c function/c
-                          sequence?
-                          sequence?)])
+  [(_ source/c) #'(map/c source/c source/c)]
+  [(_) #'(map/c any/c any/c)] ; backward compat - remove later
+  [_ #'(map/c any/c any/c)])
 
 (define-syntax-parser filter/c
   [(_ of-type/c) #'(binary-function/c (predicate/c of-type/c)
                                       (sequenceof of-type/c)
                                       (sequenceof of-type/c))]
-  [(_) #'(binary-function/c predicate/c
-                            sequence?
-                            sequence?)] ; backward compat - remove later
-  [_ #'(binary-function/c predicate/c
-                          sequence?
-                          sequence?)])
+  [(_) #'(filter/c any/c)] ; backward compat - remove later
+  [_ #'(filter/c any/c)])
 
 (define-syntax-parser reducer/c
   [(_ type/c target/c) #'(function/c (sequenceof type/c)
                                      target/c)]
-  [(_ type/c) #'(function/c (sequenceof type/c) type/c)]
-  [(_) #'(function/c sequence? any/c)] ; backward compat - remove later
-  [_ #'(function/c sequence? any/c)])
+  [(_ type/c) #'(reducer/c type/c type/c)]
+  [(_) #'(reducer/c any/c)] ; backward compat - remove later
+  [_ #'(reducer/c any/c)])
 
 (define-syntax-parser functional/c
   [(_ procedure/c) #'(self-map/c procedure/c)]
-  [(_) #'(self-map/c procedure?)] ; backward compat - remove later
-  [_ #'(self-map/c procedure?)])
+  [(_) #'(functional/c procedure?)] ; backward compat - remove later
+  [_ #'(functional/c procedure?)])
 
 (define-syntax-parser binary-constructor/c
   [(_ (~seq #:order (~datum 'abb)) primitive/c composite/c)

--- a/contract/social.rkt
+++ b/contract/social.rkt
@@ -13,8 +13,7 @@
 (version-case
  [(version< (version) "7.9.0.22")
   (define-alias define-syntax-parse-rule define-simple-macro)]
- [else
-  (define-alias define-syntax-parse-rule define-syntax-parse-rule)])
+ [else])
 
 (provide
  function/c

--- a/contract/social.rkt
+++ b/contract/social.rkt
@@ -35,10 +35,8 @@
  filter/c
  reducer/c
  functional/c
- (contract-out [binary-constructor/c (->* (contract? contract?)
-                                          (#:order (one-of/c 'abb 'bab))
-                                          contract?)]
-               [variadic-constructor/c (->* (contract? contract?)
+ binary-constructor/c
+ (contract-out [variadic-constructor/c (->* (contract? contract?)
                                             (#:order (one-of/c 'abb 'bab))
                                             contract?)]))
 
@@ -174,12 +172,14 @@
   [(_) #'(self-map/c procedure?)] ; backward compat - remove later
   [_ #'(self-map/c procedure?)])
 
-(define (binary-constructor/c primitive/c
-                              composite/c
-                              #:order [order 'abb])
-  (match order
-    ['abb (binary-function/c primitive/c composite/c composite/c)]
-    ['bab (binary-function/c composite/c primitive/c composite/c)]))
+(define-syntax-parser binary-constructor/c
+  [(_ (~seq #:order (~datum 'abb)) primitive/c composite/c)
+   #'(binary-function/c primitive/c composite/c composite/c)]
+  [(_ (~seq #:order (~datum 'bab)) primitive/c composite/c)
+   #'(binary-function/c composite/c primitive/c composite/c)]
+  [(_ primitive/c composite/c)
+   ;; default to abb order
+   #'(binary-function/c primitive/c composite/c composite/c)])
 
 (define (variadic-constructor/c primitive/c
                                 composite/c

--- a/contract/social.rkt
+++ b/contract/social.rkt
@@ -34,10 +34,8 @@
  map/c
  filter/c
  reducer/c
- (contract-out [functional/c (->* ()
-                                  (contract?)
-                                  contract?)]
-               [binary-constructor/c (->* (contract? contract?)
+ functional/c
+ (contract-out [binary-constructor/c (->* (contract? contract?)
                                           (#:order (one-of/c 'abb 'bab))
                                           contract?)]
                [variadic-constructor/c (->* (contract? contract?)
@@ -160,8 +158,10 @@
   [(_) #'(function/c sequence? any/c)] ; backward compat - remove later
   [_ #'(function/c sequence? any/c)])
 
-(define (functional/c [procedure/c procedure?])
-  (self-map/c procedure/c))
+(define-syntax-parser functional/c
+  [(_ procedure/c) #'(self-map/c procedure/c)]
+  [(_) #'(self-map/c procedure?)] ; backward compat - remove later
+  [_ #'(self-map/c procedure?)])
 
 (define (binary-constructor/c primitive/c
                               composite/c

--- a/contract/social.rkt
+++ b/contract/social.rkt
@@ -54,6 +54,8 @@
 
 (define-syntax-parser binary-function/c
   [(_ a/c b/c target/c) #'(-> a/c b/c target/c)]
+  [(_ type/c) #'(-> type/c type/c any/c)]
+  [(_ type/c target/c) #'(-> type/c type/c target/c)]
   [(_) #'(-> any/c any/c any/c)] ; backwards compat - remove later
   [_ #'(-> any/c any/c any/c)])
 

--- a/contract/social.rkt
+++ b/contract/social.rkt
@@ -26,8 +26,8 @@
  variadic-predicate/c
  encoder/c
  decoder/c
- (contract-out [hash-function/c (thunk/c contract?)]
-               [maybe/c (->* (contract?)
+ hash-function/c
+ (contract-out [maybe/c (->* (contract?)
                              (contract?)
                              contract?)]
                [binary-composition/c (self-map/c contract?)]
@@ -121,8 +121,9 @@
 (define-syntax-parse-rule (decoder/c from-type/c)
   (function/c from-type/c any/c))
 
-(define (hash-function/c)
-  (encoder/c fixnum?))
+(define-syntax-parser hash-function/c
+  [(_) #'(encoder/c fixnum?)] ; backwards compat - remove later
+  [_ #'(encoder/c fixnum?)])
 
 (define (maybe/c type/c [default/c #f])
   (or/c type/c default/c))

--- a/contract/social.rkt
+++ b/contract/social.rkt
@@ -15,28 +15,29 @@
   (define-alias define-syntax-parse-rule define-simple-macro)]
  [else])
 
-(provide
- function/c
- thunk/c
- self-map/c
- binary-function/c
- variadic-function/c
- predicate/c
- binary-predicate/c
- variadic-predicate/c
- encoder/c
- decoder/c
- hash-function/c
- maybe/c
- binary-composition/c
- variadic-composition/c
- classifier/c
- map/c
- filter/c
- reducer/c
- functional/c
- binary-constructor/c
- variadic-constructor/c)
+(provide function/c
+         thunk/c
+         self-map/c
+         binary-function/c
+         variadic-function/c
+         binary-variadic-function/c
+         predicate/c
+         binary-predicate/c
+         variadic-predicate/c
+         encoder/c
+         decoder/c
+         hash-function/c
+         maybe/c
+         binary-composition/c
+         variadic-composition/c
+         binary-variadic-composition/c
+         classifier/c
+         map/c
+         filter/c
+         reducer/c
+         functional/c
+         binary-constructor/c
+         variadic-constructor/c)
 
 (define-syntax-parser function/c
   [(_ source/c target/c) #'(-> source/c target/c)]
@@ -79,7 +80,9 @@
    #:with ··· (quote-syntax ...)
    #'(-> any/c ··· any/c)])
 
-;; review variadic as the need presents itself
+;; backwards compat
+(define-syntax-parse-rule (binary-variadic-function/c a/c b/c target/c)
+  (variadic-function/c a/c b/c target/c))
 
 (define-syntax-parser predicate/c
   [(_ on-type/c) #'(function/c on-type/c boolean?)]
@@ -121,6 +124,10 @@
 (define-syntax-parser variadic-composition/c
   [(_ type/c) #'(variadic-function/c type/c type/c)]
   [(_ type/c _) #'(variadic-function/c type/c type/c type/c)]) ; support minimum required arity instead?
+
+;; backwards compat
+(define-syntax-parse-rule (binary-variadic-composition/c type/c)
+  (variadic-composition/c type/c type/c))
 
 (define-syntax-parser classifier/c
   [(_ by-type/c) #'(binary-function/c (encoder/c by-type/c)

--- a/contract/social.rkt
+++ b/contract/social.rkt
@@ -51,8 +51,9 @@
   (function/c type/c type/c))
 
 (define-syntax-parser thunk/c
-  [(_ (~optional target/c #:defaults ([target/c #'any/c])))
-   #'(-> target/c)])
+  [(_ target/c) #'(-> target/c)]
+  [(_) #'(-> any/c)] ; backwards compat - remove later
+  [_ #'(-> any/c)])
 
 (define-syntax-parser binary-function/c
   [(_ a/c b/c target/c) #'(-> a/c b/c target/c)]
@@ -115,8 +116,8 @@
   [_ #'(encoder/c fixnum?)])
 
 (define-syntax-parser maybe/c
-  [(_ type/c (~optional default/c #:defaults ([default/c #'#f])))
-   #'(or/c type/c default/c)])
+  [(_ type/c default/c) #'(or/c type/c default/c)]
+  [(_ type/c) #'(or/c type/c #f)])
 
 (define-syntax-parse-rule (binary-composition/c type/c)
   (binary-function/c type/c type/c type/c))
@@ -126,10 +127,15 @@
   [(_ type/c _) #'(variadic-function/c type/c type/c type/c)]) ; support minimum required arity instead?
 
 (define-syntax-parser classifier/c
-  [(_ (~optional by-type/c #:defaults ([by-type/c #'any/c])))
-   #'(binary-function/c (encoder/c by-type/c)
-                        sequence?
-                        (sequenceof sequence?))])
+  [(_ by-type/c) #'(binary-function/c (encoder/c by-type/c)
+                                      sequence?
+                                      (sequenceof sequence?))]
+  [(_) #'(binary-function/c (encoder/c any/c)
+                            sequence?
+                            (sequenceof sequence?))] ; backward compat - remove later
+  [_ #'(binary-function/c (encoder/c any/c)
+                          sequence?
+                          (sequenceof sequence?))])
 
 (define-syntax-parser map/c
   [(_ source/c target/c) #'(binary-function/c (function/c source/c target/c)
@@ -146,10 +152,15 @@
                           sequence?)])
 
 (define-syntax-parser filter/c
-  [(_ (~optional of-type/c #:defaults ([of-type/c #'any/c])))
-   #'(binary-function/c (predicate/c of-type/c)
-                        (sequenceof of-type/c)
-                        (sequenceof of-type/c))])
+  [(_ of-type/c) #'(binary-function/c (predicate/c of-type/c)
+                                      (sequenceof of-type/c)
+                                      (sequenceof of-type/c))]
+  [(_) #'(binary-function/c predicate/c
+                            sequence?
+                            sequence?)] ; backward compat - remove later
+  [_ #'(binary-function/c predicate/c
+                          sequence?
+                          sequence?)])
 
 (define-syntax-parser reducer/c
   [(_ type/c target/c) #'(function/c (sequenceof type/c)

--- a/contract/social/info.rkt
+++ b/contract/social/info.rkt
@@ -1,6 +1,4 @@
 #lang info
-(define compile-omit-paths '("dev" "tests" "coverage"))
-(define test-include-paths '("tests"))
 (define clean '("compiled"
                 "doc"
                 "doc/social-contract"))

--- a/info.rkt
+++ b/info.rkt
@@ -2,6 +2,7 @@
 (define collection 'multi)
 (define deps '("base"
                "collections-lib"
+               "mischief"
                "version-case"))
 (define build-deps '("scribble-lib"
                      "scribble-abbrevs"

--- a/info.rkt
+++ b/info.rkt
@@ -1,7 +1,8 @@
 #lang info
 (define collection 'multi)
 (define deps '("base"
-               "collections-lib"))
+               "collections-lib"
+               "version-case"))
 (define build-deps '("scribble-lib"
                      "scribble-abbrevs"
                      "racket-doc"

--- a/tests/contract/social/social-contract.rkt
+++ b/tests/contract/social/social-contract.rkt
@@ -577,7 +577,7 @@
     (test-case
         "bab"
       (define/contract (g a b)
-        (binary-constructor/c number? list? #:order 'bab)
+        (binary-constructor/c #:order 'bab number? list?)
         (list 5))
       (check-equal? (g (list 3) 5) (list 5))
       (check-exn exn:fail:contract? (thunk (g (list 5))))

--- a/tests/contract/social/social-contract.rkt
+++ b/tests/contract/social/social-contract.rkt
@@ -180,6 +180,13 @@
     (test-case
         "All default contracts"
       (define/contract (g . as)
+        variadic-function/c
+        5)
+      (check-equal? (g -1 -2 -5) 5)
+      (check-equal? (g "hi" -2 -5) 5))
+    (test-case
+        "All default contracts - backwards compat"
+      (define/contract (g . as)
         (variadic-function/c)
         5)
       (check-equal? (g -1 -2 -5) 5)

--- a/tests/contract/social/social-contract.rkt
+++ b/tests/contract/social/social-contract.rkt
@@ -399,14 +399,11 @@
       (check-equal? (g 1) 5)
       (check-equal? (g) 5)
       (check-exn exn:fail:contract? (thunk (g "1")))
-      (check-exn exn:fail:contract? (thunk (g 1 "2")))))
-
-   (test-suite
-    "binary-variadic-composition/c"
+      (check-exn exn:fail:contract? (thunk (g 1 "2"))))
     (test-case
-        "Basic"
+        "Binary"
       (define/contract (g . as)
-        (binary-variadic-composition/c number?)
+        (variadic-composition/c number? number?)
         5)
       (check-equal? (g 1 2) 5)
       (check-equal? (g 1 2 3) 5)

--- a/tests/contract/social/social-contract.rkt
+++ b/tests/contract/social/social-contract.rkt
@@ -203,37 +203,15 @@
     (test-case
         "Basic"
       (define/contract (g . as)
-        (binary-variadic-function/c number? list? number?)
+        (variadic-function/c number? list? number?)
         5)
       (check-equal? (g 3 (list 1 2) null) 5)
       (check-equal? (g 3) 5)
       (check-exn exn:fail:contract? (thunk (g (list 1 2) null))))
     (test-case
-        "Defaults with no parameters"
-      (define/contract (g . as)
-        (binary-variadic-function/c)
-        5)
-      (check-equal? (g 2 3) 5)
-      (check-equal? (g 1) 5)
-      (check-exn exn:fail:contract? (thunk (g))))
-    (test-case
-        "Default variadic contract"
-      (define/contract (g . as)
-        (binary-variadic-function/c number?)
-        5)
-      (check-equal? (g 4 5 6) 5)
-      (check-exn exn:fail:contract? (thunk (g (list 1 2)))))
-    (test-case
-        "Default output contract"
-      (define/contract (g . as)
-        (binary-variadic-function/c number? list?)
-        5)
-      (check-equal? (g 3 (list 1 2) null) 5)
-      (check-exn exn:fail:contract? (thunk (g 3 5))))
-    (test-case
         "Variadic head"
       (define/contract (g . as)
-        (binary-variadic-function/c number? list? #:tail? #t)
+        (variadic-function/c number? (tail list?) number?)
         5)
       (check-equal? (g 3 4 5 (list 1 2)) 5)
       (check-equal? (g (list 1 2)) 5)

--- a/tests/contract/social/social-contract.rkt
+++ b/tests/contract/social/social-contract.rkt
@@ -229,6 +229,14 @@
     (test-case
         "Defaults with no parameters"
       (define/contract (g . as)
+        predicate/c
+        #t)
+      (check-true (g 5))
+      (check-true (g null))
+      (check-exn exn:fail:contract? (thunk (g))))
+    (test-case
+        "Defaults with no parameters - backwards compat"
+      (define/contract (g . as)
         (predicate/c)
         #t)
       (check-true (g 5))
@@ -255,6 +263,13 @@
     (test-case
         "Defaults with no parameters"
       (define/contract (g . as)
+        binary-predicate/c
+        #t)
+      (check-true (g 5 "hi"))
+      (check-exn exn:fail:contract? (thunk (g 5))))
+    (test-case
+        "Defaults with no parameters - backwards compat"
+      (define/contract (g . as)
         (binary-predicate/c)
         #t)
       (check-true (g 5 "hi"))
@@ -278,6 +293,14 @@
         #t)
       (check-true (g 5))
       (check-true (g "hi"))
+      (check-true (g)))
+    (test-case
+        "Defaults with no parameters - backwards compat"
+      (define/contract (g . as)
+        (variadic-predicate/c)
+        #t)
+      (check-true (g 5))
+      (check-true (g "hi"))
       (check-true (g))))
 
    (test-suite
@@ -285,31 +308,20 @@
     (test-case
         "Basic"
       (define/contract (g . as)
-        (binary-variadic-predicate/c number? string?)
+        (variadic-predicate/c number? string?)
         #t)
       (check-true (g 2 "hi" "bye"))
       (check-true (g 2))
       (check-exn exn:fail:contract? (thunk (g "hi")))
       (check-exn exn:fail:contract? (thunk (g))))
     (test-case
-        "Defaults with no parameters"
+        "Variadic head"
       (define/contract (g . as)
-        (binary-variadic-predicate/c)
+        (variadic-predicate/c number? (tail list?))
         #t)
-      (check-true (g 2 3 5))
-      (check-true (g 2 "hi" 5))
-      (check-true (g 2))
-      (check-exn exn:fail:contract? (thunk (g))))
-    (test-case
-        "Default with one parameter"
-      (define/contract (g . as)
-        (binary-variadic-predicate/c number?)
-        #t)
-      ;;... and tail
-      (check-true (g 5))
-      (check-true (g 5 6 7))
-      (check-exn exn:fail:contract? (thunk (g 5 "hi")))
-      (check-exn exn:fail:contract? (thunk (g)))))
+      (check-true (g 3 4 5 (list 1 2)))
+      (check-true (g (list 1 2)))
+      (check-exn exn:fail:contract? (thunk (g 5)))))
 
    (test-suite
     "encoder/c"

--- a/tests/contract/social/social-contract.rkt
+++ b/tests/contract/social/social-contract.rkt
@@ -107,7 +107,23 @@
       (define/contract (list-thunk)
         (thunk/c list?)
         0)
-      (check-exn exn:fail:contract? (thunk (list-thunk)))))
+      (check-exn exn:fail:contract? (thunk (list-thunk))))
+    (test-case
+        "any"
+      (define/contract (g)
+        (thunk/c any)
+        (values 0 1))
+      (check-equal? (values->list (g))
+                    (list 0 1))
+      (check-exn exn:fail:contract? (thunk (g "hello"))))
+    (test-case
+        "values"
+      (define/contract (g)
+        (thunk/c (values positive? negative?))
+        (values 1 -1))
+      (check-equal? (values->list (g))
+                    (list 1 -1))
+      (check-exn exn:fail:contract? (thunk (g "hello")))))
 
    (test-suite
     "binary-function/c"

--- a/tests/contract/social/social-contract.rkt
+++ b/tests/contract/social/social-contract.rkt
@@ -43,22 +43,22 @@
       (check-equal? (g "hello") 0)
       (check-exn exn:fail:contract? (thunk (g '(h e l l o) '(h e l l o))))
       (check-exn exn:fail:contract? (thunk (g))))
-    ;; (test-case
-    ;;     "any"
-    ;;   (define/contract (g lst)
-    ;;     (function/c list? any)
-    ;;     (values 0 1))
-    ;;   (check-equal? (values->list (g '(h e l l o)))
-    ;;                 (list 0 1))
-    ;;   (check-exn exn:fail:contract? (thunk (g "hello"))))
-    ;; (test-case
-    ;;     "values"
-    ;;   (define/contract (g lst)
-    ;;     (function/c list? (values positive? negative?))
-    ;;     (values 1 -1))
-    ;;   (check-equal? (values->list (g '(h e l l o)))
-    ;;                 (list 1 -1))
-    ;;   (check-exn exn:fail:contract? (thunk (g "hello"))))
+    (test-case
+        "any"
+      (define/contract (g lst)
+        (function/c list? any)
+        (values 0 1))
+      (check-equal? (values->list (g '(h e l l o)))
+                    (list 0 1))
+      (check-exn exn:fail:contract? (thunk (g "hello"))))
+    (test-case
+        "values"
+      (define/contract (g lst)
+        (function/c list? (values positive? negative?))
+        (values 1 -1))
+      (check-equal? (values->list (g '(h e l l o)))
+                    (list 1 -1))
+      (check-exn exn:fail:contract? (thunk (g "hello"))))
     ;; (test-case
     ;;     "case->"
     ;;   (define/contract (g lst)

--- a/tests/contract/social/social-contract.rkt
+++ b/tests/contract/social/social-contract.rkt
@@ -156,6 +156,20 @@
       (check-equal? (g 2 -3) -6)
       (check-exn exn:fail:contract? (thunk (g -2 3))))
     (test-case
+        "input contracts"
+      (define/contract (g a b)
+        (binary-function/c positive?)
+        "hello")
+      (check-equal? (g 2 3) "hello")
+      (check-exn exn:fail:contract? (thunk (g -2 3))))
+    (test-case
+        "input and target contracts"
+      (define/contract (g a b)
+        (binary-function/c positive? string?)
+        "hello")
+      (check-equal? (g 2 3) "hello")
+      (check-exn exn:fail:contract? (thunk (g -2 3))))
+    (test-case
         "Return value"
       (define/contract (g a b)
         (binary-function/c positive? negative? negative?)

--- a/tests/contract/social/social-contract.rkt
+++ b/tests/contract/social/social-contract.rkt
@@ -118,6 +118,18 @@
         0)
       (check-exn exn:fail:contract? (thunk (list-thunk))))
     (test-case
+        "Defaults with no parameters"
+      (define/contract (g)
+        thunk/c
+        0)
+      (check-equal? (g) 0))
+    (test-case
+        "Defaults with no parameters - backwards compat"
+      (define/contract (g)
+        (thunk/c)
+        0)
+      (check-equal? (g) 0))
+    (test-case
         "any"
       (define/contract (g)
         (thunk/c any)
@@ -289,7 +301,7 @@
     (test-case
         "Defaults with no parameters"
       (define/contract (g . as)
-        (variadic-predicate/c)
+        variadic-predicate/c
         #t)
       (check-true (g 5))
       (check-true (g "hi"))

--- a/tests/contract/social/social-contract.rkt
+++ b/tests/contract/social/social-contract.rkt
@@ -603,7 +603,7 @@
     (test-case
         "bab"
       (define/contract (g . as)
-        (variadic-constructor/c number? list? #:order 'bab)
+        (variadic-constructor/c #:order 'bab number? list?)
         (list 5))
       (check-equal? (g (list 3) 1) (list 5))
       (check-equal? (g (list 3) 1 2 3) (list 5))

--- a/tests/contract/social/social-contract.rkt
+++ b/tests/contract/social/social-contract.rkt
@@ -349,6 +349,14 @@
     (test-case
         "Basic"
       (define/contract (g v)
+        hash-function/c
+        5)
+      (check-equal? (g "hi") 5)
+      (check-equal? (g null) 5)
+      (check-exn exn:fail:contract? (thunk (g))))
+    (test-case
+        "Basic - backwards compat"
+      (define/contract (g v)
         (hash-function/c)
         5)
       (check-equal? (g "hi") 5)

--- a/tests/contract/social/social-contract.rkt
+++ b/tests/contract/social/social-contract.rkt
@@ -44,20 +44,33 @@
       (check-exn exn:fail:contract? (thunk (g '(h e l l o) '(h e l l o))))
       (check-exn exn:fail:contract? (thunk (g))))
     ;; (test-case
-    ;;     "any with single value"
-    ;;   (define/contract (list-to-any lst)
-    ;;     (function/c list? any)
-    ;;     0)
-    ;;   (check-equal? (list-to-any '(h e l l o)) 0)
-    ;;   (check-exn exn:fail:contract? (thunk (list-to-any "hello"))))
-    ;; (test-case
-    ;;     "any with multiple values"
-    ;;   (define/contract (list-to-any lst)
+    ;;     "any"
+    ;;   (define/contract (g lst)
     ;;     (function/c list? any)
     ;;     (values 0 1))
-    ;;   (check-equal? (values->list (list-to-any '(h e l l o)))
+    ;;   (check-equal? (values->list (g '(h e l l o)))
     ;;                 (list 0 1))
-    ;;   (check-exn exn:fail:contract? (thunk (list-to-any "hello"))))
+    ;;   (check-exn exn:fail:contract? (thunk (g "hello"))))
+    ;; (test-case
+    ;;     "values"
+    ;;   (define/contract (g lst)
+    ;;     (function/c list? (values positive? negative?))
+    ;;     (values 1 -1))
+    ;;   (check-equal? (values->list (g '(h e l l o)))
+    ;;                 (list 1 -1))
+    ;;   (check-exn exn:fail:contract? (thunk (g "hello"))))
+    ;; (test-case
+    ;;     "case->"
+    ;;   (define/contract (g lst)
+    ;;     (case->
+    ;;      (function/c string? number?)
+    ;;      (function/c list?))
+    ;;     (case-lambda
+    ;;       [() (list 1 2)]
+    ;;       [(arg) 0]))
+    ;;   (check-equal? (g "hello") 0)
+    ;;   (check-equal? (g) (list 1 2))
+    ;;   (check-exn exn:fail:contract? (thunk (g 1))))
     )
 
    (test-suite

--- a/tests/contract/social/social-contract.rkt
+++ b/tests/contract/social/social-contract.rkt
@@ -218,11 +218,12 @@
       (check-equal? (g -1 -2 -5) 5)
       (check-equal? (g "hi" -2 -5) 5))
     (test-case
-        "Default output to input contract"
+        "Default output to any/c"
       (define/contract (g . as)
         (variadic-function/c negative?)
-        -5)
-      (check-equal? (g -1 -2 -5) -5)))
+        "hello")
+      (check-equal? (g -1 -2 -5) "hello")
+      (check-exn exn:fail:contract? (thunk (g -1 -2 5)))))
 
    (test-suite
     "binary-variadic-function/c"

--- a/tests/contract/social/social-contract.rkt
+++ b/tests/contract/social/social-contract.rkt
@@ -152,23 +152,15 @@
     (test-case
         "All default contracts"
       (define/contract (g a b)
-        (binary-function/c)
+        binary-function/c
         (* a b))
       (check-equal? (g 2 -3) -6))
     (test-case
-        "Default to first input contract"
+        "All default contracts - backwards compat"
       (define/contract (g a b)
-        (binary-function/c positive?)
+        (binary-function/c)
         (* a b))
-      (check-equal? (g 2 3) 6)
-      (check-exn exn:fail:contract? (thunk (g -2 3))))
-    (test-case
-        "Default output to first input contracts"
-      (define/contract (g a b)
-        (binary-function/c negative? positive?)
-        (* a b))
-      (check-equal? (g -3 2) -6)
-      (check-exn exn:fail:contract? (thunk (g 3 -2)))))
+      (check-equal? (g 2 -3) -6)))
 
    (test-suite
     "variadic-function/c"

--- a/tests/contract/social/social-contract.rkt
+++ b/tests/contract/social/social-contract.rkt
@@ -37,6 +37,15 @@
     (test-case
         "Defaults with no parameters"
       (define/contract (g lst)
+        function/c
+        0)
+      (check-equal? (g '(h e l l o)) 0)
+      (check-equal? (g "hello") 0)
+      (check-exn exn:fail:contract? (thunk (g '(h e l l o) '(h e l l o))))
+      (check-exn exn:fail:contract? (thunk (g))))
+    (test-case
+        "Defaults with no parameters - backwards compat"
+      (define/contract (g lst)
         (function/c)
         0)
       (check-equal? (g '(h e l l o)) 0)


### PR DESCRIPTION
At the moment these "social" contracts are implemented as functions that evaluate to contracts based on the provided arguments. This prohibits their use in some forms in the Racket contract DSL that expect to be used syntactically within a contract specification form like `->`.

This changes most of the contracts to be macros so that they fit seamlessly into all existing contract specification forms.
